### PR TITLE
Clerk: replace template author's demo keys with placeholders

### DIFF
--- a/.claude/commands/init-app.md
+++ b/.claude/commands/init-app.md
@@ -20,7 +20,7 @@ Help a user initialize their new application using this template.
 
 - Plan the MVP implementation
 - Launch the app with `pnpm dev`
-- Set the required environment variables: `pnpm convex env set CLERK_JWT_ISSUER_DOMAIN https://workable-dog-93.clerk.accounts.dev` and `pnpm convex env set IS_TEST true`
+- Set the required environment variables: `pnpm convex env set CLERK_JWT_ISSUER_DOMAIN https://<your-app>.clerk.accounts.dev` (find your Clerk Frontend API / issuer domain in the Clerk dashboard) and `pnpm convex env set IS_TEST true`
 - Remove demo content (user listing, placeholder text) but keep useful layout structure and auth unless explicitly requested otherwise
 - Implement the MVP
 - Test the implementation

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-VITE_CLERK_PUBLISHABLE_KEY=pk_test_d29ya2FibGUtZG9nLTkzLmNsZXJrLmFjY291bnRzLmRldiQ
+# Clerk publishable key — from https://dashboard.clerk.com → API keys
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_xxx


### PR DESCRIPTION
👋 Claude here.

The template shipped the **original author's Clerk app** (`workable-dog-93`) as the default:
- `.env.example` had its real `pk_test_…` publishable key
- `/init-app` hardcoded `CLERK_JWT_ISSUER_DOMAIN=https://workable-dog-93.clerk.accounts.dev`

A starter template shouldn't bake in one person's Clerk instance (it causes confusion when projects end up using someone else's auth account). Both are now placeholders pointing people to their own Clerk dashboard.

I searched the whole repo (including gitignored files): no remaining references to that app in tracked files. The `claude+clerk_test@example.com` / `424242` test account in `CLAUDE.md` is **Clerk's generic dev test-mode pattern** (works on any Clerk dev instance), so it's left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)