### PR TITLE
Quick wins: users auth fixes, prettierignore, Code Bloom branding

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,5 +6,6 @@ build/
 .convex/
 
 convex/_generated/
+src/routeTree.gen.ts
 
 coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Always follow the guidelines in this file, unless explicitly told otherwise by t
 - Add `"use node";` to the top of files containing actions that use Node.js built-in modules (can't contain queries and mutations)
 - `"use node";` is NOT needed for fetch, only use it for other Node.js built-ins
 - Convex + Clerk: Always use Convex's auth hooks (`useConvexAuth`) and components (`<Authenticated>`, `<Unauthenticated>`, `<AuthLoading>`) instead of Clerk's hooks/components. This ensures auth tokens are properly validated by the Convex backend.
+- Clerk session ≠ Convex user row exists yet (first-login provisioning race) — read queries should tolerate a missing user (return null/empty); only mutations/post-provisioning code should use `getCurrentUserOrCrash`
 - Import data with `pnpm convex import --table tableName file.json`
 
 ### Function guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,10 +118,10 @@ Always follow the guidelines in this file, unless explicitly told otherwise by t
 ## TanStack Query + Convex Integration
 
 - Use `convexQuery()` from `@convex-dev/react-query` to create query options: `const queryOptions = convexQuery(api.module.function, { status: "active" })`
-- Preload in route loaders: `loader: async ({ context: { queryClient } }) => await queryClient.ensureQueryData(queryOptions)`
+- Public queries: preload in route loaders: `loader: async ({ context: { queryClient } }) => await queryClient.ensureQueryData(queryOptions)`
+- Authed queries (using `ctx.auth`): NO loader preload (loaders run on hard refresh before Clerk restores the session) - fetch via `useSuspenseQuery` inside `<Authenticated>`
 - Use `useSuspenseQuery` in components: `const { data } = useSuspenseQuery(queryOptions)`
 - For mutations, continue using Convex's `useMutation` directly
-- **When adding auth to a query** (`ctx.auth.getUserIdentity()`), update its loader: `if ((window as any).Clerk?.session) await queryClient.ensureQueryData(authQuery)` - otherwise the app crashes on page refresh
 
 ## TanStack Form + Zod v4
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -27,6 +27,8 @@ export async function getCurrentUserOrCrash(ctx: QueryCtx | MutationCtx) {
   if (!user) {
     throw new ConvexError("Not authenticated");
   }
+
+  return user;
 }
 
 export const ensureUser = mutation({

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -65,6 +65,8 @@ export const ensureUser = mutation({
 export const listUsers = query({
   args: {},
   handler: async (ctx) => {
+    await getCurrentUserOrCrash(ctx);
+
     const users = await ctx.db.query("users").collect();
     return users;
   },

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -7,18 +7,12 @@ export async function getCurrentUserOrNull(ctx: QueryCtx | MutationCtx) {
     return null;
   }
 
-  const user = await ctx.db
+  // Null when authenticated but the user row isn't provisioned yet
+  // (first-login race) - this is a normal transient state, not a bug.
+  return await ctx.db
     .query("users")
     .withIndex("by_clerkId", (q) => q.eq("clerkId", identity.subject))
     .unique();
-
-  if (!user) {
-    throw new ConvexError(
-      "Bug: User is authenticated with convex but is missing a record in the DB",
-    );
-  }
-
-  return user;
 }
 
 export async function getCurrentUserOrCrash(ctx: QueryCtx | MutationCtx) {
@@ -65,7 +59,18 @@ export const ensureUser = mutation({
 export const listUsers = query({
   args: {},
   handler: async (ctx) => {
-    await getCurrentUserOrCrash(ctx);
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new ConvexError("Not authenticated");
+    }
+
+    const user = await getCurrentUserOrNull(ctx);
+    if (!user) {
+      // User row not provisioned yet (first login). Inserting it invalidates
+      // this query's read set, so Convex re-runs it and the client transitions
+      // [] -> full list automatically.
+      return [];
+    }
 
     const users = await ctx.db.query("users").collect();
     return users;

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/code-bloom.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/src/index.css" />
-    <title>Vite + React + TS</title>
+    <title>Code Bloom</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fullstack-vibe-coding",
+  "name": "code-bloom",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -99,7 +99,7 @@ function RootComponent() {
                     to="/"
                     className="text-xl font-semibold hover:opacity-80 transition-opacity"
                   >
-                    Fullstack Vibe Coding
+                    Code Bloom
                   </Link>
 
                   {/* Desktop nav */}
@@ -126,14 +126,14 @@ function RootComponent() {
               </main>
 
               <footer className="border-t py-4 text-center text-sm text-muted-foreground">
-                <p>© {new Date().getFullYear()} Fullstack Vibe Coding</p>
+                <p>© {new Date().getFullYear()} Code Bloom</p>
               </footer>
             </Authenticated>
 
             <Unauthenticated>
               <header className="border-b bg-background shadow-sm">
                 <div className="container mx-auto flex h-14 items-center justify-between px-4">
-                  <h1 className="font-semibold">Fullstack Vibe Coding</h1>
+                  <h1 className="font-semibold">Code Bloom</h1>
                   <div className="flex gap-2">
                     <SignInButton mode="modal">
                       <Button size="sm">Sign in</Button>
@@ -150,7 +150,7 @@ function RootComponent() {
                 <Outlet />
               </main>
               <footer className="border-t py-4 text-center text-sm text-muted-foreground">
-                <p>© {new Date().getFullYear()} Fullstack Vibe Coding</p>
+                <p>© {new Date().getFullYear()} Code Bloom</p>
               </footer>
             </Unauthenticated>
           </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -27,7 +27,7 @@ function HomePage() {
       <div className="flex justify-center mb-4">
         <Zap className="w-16 h-16 text-primary" />
       </div>
-      <h1 className="text-3xl font-bold mb-4">Fullstack Vibe Coding</h1>
+      <h1 className="text-3xl font-bold mb-4">Code Bloom</h1>
 
       <Unauthenticated>
         <p className="mb-4 text-muted-foreground">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -18,8 +18,6 @@ import {
 const usersQueryOptions = convexQuery(api.users.listUsers, {});
 
 export const Route = createFileRoute("/")({
-  loader: async ({ context: { queryClient } }) =>
-    await queryClient.ensureQueryData(usersQueryOptions),
   component: HomePage,
 });
 


### PR DESCRIPTION
👋 Claude here

Four small fixes, one commit each:

1. **`users: fix getCurrentUserOrCrash to return the user`** — it threw on null but was missing `return user;`, so callers always got `undefined`.
2. **`users: require auth for listUsers`** — `listUsers` was publicly queryable. Per the owner's decision:
   > listUsers: Ok, we can allow only logged in users.

   It now rejects unauthenticated callers with a `ConvexError`. Since the query is now authed, the route loader prefetch in `src/routes/index.tsx` was removed — loaders run on hard refresh before Clerk restores the session, so an authed prefetch there would crash for signed-in users. The data is fetched via `useSuspenseQuery` inside `<Authenticated>` instead. CLAUDE.md's TanStack Query + Convex section was updated to state this public-vs-authed convention (replacing the `(window as any).Clerk?.session` loader hack).
3. **`prettierignore: +src/routeTree.gen.ts`** — the generated file's own header says to exclude it from formatting, but `pnpm format` was rewriting it.
4. **`branding: unify on Code Bloom`** — README already said "Code Bloom" (matching code-bloom.app), but `index.html` had the Vite default title, the UI headers said "Fullstack Vibe Coding", and `package.json` was named `fullstack-vibe-coding`. All now say Code Bloom / `code-bloom` (nothing referenced the old package name).

**Review fix** (follow-up commit): the authed `listUsers` raced first-login provisioning — the query could run before `ensureUser` inserted the user row and hit the "Bug: ... missing a record in the DB" error. `getCurrentUserOrNull` now returns `null` for that transient state instead of throwing, and `listUsers` returns `[]` for a not-yet-provisioned caller; Convex reactivity re-runs the query once the row is inserted, so the client transitions to the full list automatically.

Verified: `pnpm lint` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrVv49ZydmFUGUVbVTGWeN