### PR TITLE
Auth semantics: backend crashes on unauthorized, frontend gates via AuthenticatedAndProvisioned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ Always follow the guidelines in this file, unless explicitly told otherwise by t
 - Add `"use node";` to the top of files containing actions that use Node.js built-in modules (can't contain queries and mutations)
 - `"use node";` is NOT needed for fetch, only use it for other Node.js built-ins
 - Convex + Clerk: Always use Convex's auth hooks (`useConvexAuth`) and components (`<Authenticated>`, `<Unauthenticated>`, `<AuthLoading>`) instead of Clerk's hooks/components. This ensures auth tokens are properly validated by the Convex backend.
-- Clerk session ≠ Convex user row exists yet (first-login provisioning race) — read queries should tolerate a missing user (return null/empty); only mutations/post-provisioning code should use `getCurrentUserOrCrash`
+- Backend functions for logged-in users crash on unauthorized callers via `getCurrentUserOrCrash` (never return empty results to hide missing permissions)
+- It's the frontend's responsibility not to call functions it lacks permission for: call them only inside `<AuthenticatedAndProvisioned>` (Clerk session ≠ Convex user row exists yet on first login)
 - Import data with `pnpm convex import --table tableName file.json`
 
 ### Function guidelines

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -56,21 +56,17 @@ export const ensureUser = mutation({
   },
 });
 
+export const getCurrentUser = query({
+  args: {},
+  handler: async (ctx) => {
+    return await getCurrentUserOrNull(ctx);
+  },
+});
+
 export const listUsers = query({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) {
-      throw new ConvexError("Not authenticated");
-    }
-
-    const user = await getCurrentUserOrNull(ctx);
-    if (!user) {
-      // User row not provisioned yet (first login). Inserting it invalidates
-      // this query's read set, so Convex re-runs it and the client transitions
-      // [] -> full list automatically.
-      return [];
-    }
+    await getCurrentUserOrCrash(ctx);
 
     const users = await ctx.db.query("users").collect();
     return users;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "init": "pnpm install && cp .env.example .env.local && convex login && convex dev --once || true && claude ${RUNNING_IN_CONTAINER:+--dangerously-skip-permissions} '/init-app'",
+    "init": "pnpm install && ([ -f .env.local ] || cp .env.example .env.local) && convex login && convex dev --once && claude ${RUNNING_IN_CONTAINER:+--dangerously-skip-permissions} '/init-app'",
     "dev": "npm-run-all --parallel dev:frontend dev:backend",
     "dev:frontend": "vite --open",
     "dev:backend": "convex dev",

--- a/src/components/AuthenticatedAndProvisioned.tsx
+++ b/src/components/AuthenticatedAndProvisioned.tsx
@@ -1,0 +1,37 @@
+import { convexQuery } from "@convex-dev/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Authenticated } from "convex/react";
+import type { ReactNode } from "react";
+import { api } from "../../convex/_generated/api";
+
+/**
+ * Renders children only when the caller is authenticated AND their user row
+ * exists, so children may call backend functions that crash on unauthorized
+ * callers (getCurrentUserOrCrash).
+ */
+export function AuthenticatedAndProvisioned({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <Authenticated>
+      <ProvisionedGate>{children}</ProvisionedGate>
+    </Authenticated>
+  );
+}
+
+function ProvisionedGate({ children }: { children: ReactNode }) {
+  const { data: currentUser } = useSuspenseQuery(
+    convexQuery(api.users.getCurrentUser, {}),
+  );
+
+  // Null on a brand-new sign-in while the user row is being created. Inserting
+  // the row invalidates the query's read set, so Convex re-runs it and the
+  // children render automatically - no polling needed.
+  if (currentUser === null) {
+    return null;
+  }
+
+  return children;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,9 +2,10 @@ import { SignInButton } from "@clerk/clerk-react";
 import { convexQuery } from "@convex-dev/react-query";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { Authenticated, Unauthenticated } from "convex/react";
+import { Unauthenticated } from "convex/react";
 import { Zap } from "lucide-react";
 import { api } from "../../convex/_generated/api";
+import { AuthenticatedAndProvisioned } from "@/components/AuthenticatedAndProvisioned";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -38,9 +39,9 @@ function HomePage() {
         </SignInButton>
       </Unauthenticated>
 
-      <Authenticated>
+      <AuthenticatedAndProvisioned>
         <UsersList />
-      </Authenticated>
+      </AuthenticatedAndProvisioned>
     </div>
   );
 }


### PR DESCRIPTION
👋 Claude here

Follow-up to #10, refining the auth design per the owner's decision:

> listUsers should *not* return an empty list if the user has no auth, but rather *crash*. it's the frontend's responsibility not to call functions that the client doesn't have permissions for

- **`convex/users.ts`**: `listUsers` now just does `await getCurrentUserOrCrash(ctx)` — it crashes (`ConvexError("Not authenticated")`) for both logged-out and not-yet-provisioned callers, instead of the `return []` race tolerance from #10. Added a `getCurrentUser` public query (the canonical "who am I": returns the user, or `null` when logged out / unprovisioned). `getCurrentUserOrNull` keeps returning `null` during the first-login provisioning race.
- **`src/components/AuthenticatedAndProvisioned.tsx`** (new): wraps children in Convex's `<Authenticated>` plus a gate on `useSuspenseQuery(getCurrentUser)` that renders nothing while the user row is still being created on a brand-new sign-in — Convex reactivity re-runs the query the moment the insert lands, so it self-heals without polling. `src/routes/index.tsx` now uses it around `UsersList` (the `<Unauthenticated>` branch is unchanged).
- **CLAUDE.md**: updated the convention — backend functions for logged-in users crash via `getCurrentUserOrCrash` (never return empty results to hide missing permissions); the frontend only calls them inside `<AuthenticatedAndProvisioned>`.
- **`package.json` init script**: re-running no longer clobbers an existing `.env.local` (`[ -f .env.local ] || cp ...`, portable across BSD/GNU), and removed the `|| true` so failures stop the chain loudly instead of continuing into the `claude` launch.

Verified: `pnpm lint` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrVv49ZydmFUGUVbVTGWeN