### PR TITLE
Error visibility: route error fallback + not-found page

### DIFF
--- a/src/components/NotFoundFallback.tsx
+++ b/src/components/NotFoundFallback.tsx
@@ -1,0 +1,13 @@
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+
+export function NotFoundFallback() {
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col items-start gap-4 p-6">
+      <h1 className="text-2xl font-semibold">Page not found</h1>
+      <Button asChild>
+        <Link to="/">Go home</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/RouteErrorFallback.tsx
+++ b/src/components/RouteErrorFallback.tsx
@@ -1,0 +1,55 @@
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+import { useRouter, type ErrorComponentProps } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+// Retry wiring per
+// https://tanstack.com/router/latest/docs/framework/react/guide/external-data-loading#error-handling-with-tanstack-query
+export function RouteErrorFallback({ error, reset }: ErrorComponentProps) {
+  const router = useRouter();
+  const queryErrorResetBoundary = useQueryErrorResetBoundary();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    // Reset TanStack Query's error boundary so errored queries refetch on retry
+    queryErrorResetBoundary.reset();
+  }, [queryErrorResetBoundary]);
+
+  const fullError = error.stack?.includes(error.message)
+    ? error.stack
+    : [error.message, error.stack].filter(Boolean).join("\n\n");
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-4 bg-background p-6">
+      <h1 className="text-2xl font-semibold text-destructive">
+        Something went wrong
+      </h1>
+      <pre className="max-h-96 overflow-auto whitespace-pre-wrap rounded-md border bg-muted p-4 text-sm select-text">
+        {fullError}
+      </pre>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant="outline"
+          onClick={() =>
+            void navigator.clipboard
+              .writeText(fullError)
+              .then(() => setCopied(true))
+          }
+        >
+          {copied ? "Copied!" : "Copy error"}
+        </Button>
+        <Button
+          onClick={() => {
+            reset();
+            void router.invalidate();
+          }}
+        >
+          Try again
+        </Button>
+        <Button variant="outline" onClick={() => location.reload()}>
+          Reload page
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,8 @@ import "./index.css";
 
 import { env } from "./env";
 import { routeTree } from "./routeTree.gen";
+import { RouteErrorFallback } from "@/components/RouteErrorFallback";
+import { NotFoundFallback } from "@/components/NotFoundFallback";
 
 // Create clients outside of components to avoid recreating them on re-renders
 const convex = new ConvexReactClient(env.VITE_CONVEX_URL);
@@ -39,6 +41,9 @@ const router = createRouter({
   // over the WebSocket): https://tanstack.com/router/latest/docs/framework/react/guide/preloading
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
+  // App-wide fallbacks: https://tanstack.com/router/latest/docs/framework/react/guide/not-found-errors
+  defaultErrorComponent: RouteErrorFallback,
+  defaultNotFoundComponent: NotFoundFallback,
   context: {
     queryClient,
     convexClient: convex,


### PR DESCRIPTION
👋 Claude here

Previously an uncaught route/render error meant a blank page (no `errorComponent` anywhere), and unknown URLs had no not-found page. This PR adds app-wide fallbacks for both, following the owner's preference:

> I prefer having visible errors to make debug easy

## What's included

**`src/components/RouteErrorFallback.tsx`**
- "Something went wrong" heading + the FULL error message and stack in a scrollable, selectable `<pre>` (never truncated)
- Actions: **Copy error** (clipboard, full text), **Try again**, **Reload page**
- "Try again" uses the wiring recommended in the TanStack Router docs ([external data loading → error handling with TanStack Query](https://tanstack.com/router/latest/docs/framework/react/guide/external-data-loading#error-handling-with-tanstack-query)): `useQueryErrorResetBoundary().reset()` on mount so errored queries refetch, then `reset()` + `router.invalidate()` to re-run loaders and reset the router error boundary

**`src/components/NotFoundFallback.tsx`**
- "Page not found" + a `<Link to="/">` home button

**Registration** (`src/main.tsx`)
- `defaultErrorComponent` / `defaultNotFoundComponent` on `createRouter`, per the [not-found errors guide](https://tanstack.com/router/latest/docs/framework/react/guide/not-found-errors) which recommends a router-level `defaultNotFoundComponent` for app-wide handling — keeps `__root.tsx` untouched

No demo/error-throwing route included on purpose. Verified with `pnpm lint` + `pnpm build` (both pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrVv49ZydmFUGUVbVTGWeN
