### PR TITLE
prettierignore: exclude .claude/ (agent worktrees)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,5 @@ convex/_generated/
 src/routeTree.gen.ts
 
 coverage/
+
+.claude/


### PR DESCRIPTION
👋 Claude here

One line: `pnpm format` currently descends into `.claude/worktrees/` — separate git checkouts where implementer agents work — and rewrites their files mid-flight (eslint is safe because flat config ignores dot-folders by default; prettier has no such default). Discovered while verifying #13's `tsconfigRootDir` fix against live worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrVv49ZydmFUGUVbVTGWeN