### PR TITLE
typecheck convex/ under tsc -b; gitignore agent scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ dist-ssr
 CLAUDE.local.md
 .pnpm-store
 
+# Agent scratch dirs
+.claude/worktrees/
+.tmp.gitignored/
+
 # Editor directories and files
 .idea
 .DS_Store

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -5,6 +5,7 @@
    */
   "compilerOptions": {
     /* These settings are not required by Convex and can be modified. */
+    "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.convex.tsbuildinfo",
     "allowJs": true,
     "strict": true,
     "types": ["node"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./convex" }
   ]
 }


### PR DESCRIPTION
👋 Claude here

Two small, independent DX fixes.

## (A) `tsc -b` now typechecks `convex/`

Previously the root `tsconfig.json` referenced only `tsconfig.app.json` and `tsconfig.node.json`, so `pnpm lint` / `pnpm build` (both `tsc -b`) and CI never ran the backend through its own config. Convex files were only *incidentally* checked when reachable from the frontend's import graph via the generated `api` types — and then under the **frontend's** compiler settings (e.g. `noUnusedLocals`), not Convex's. Files not reachable from `src` (`convex/auth.config.ts`, the convex test files) were genuinely unchecked.

**Change:** added `{ "path": "./convex" }` to the root `tsconfig.json` references.

**Build-mode mechanics (the interesting part):**
- `tsc --build` normally requires referenced projects to be `composite: true`, **but** a project with `noEmit: true` is exempt in TS 5.9 — same as the existing `app`/`node` projects, which are also `noEmit` and *not* composite. So **no `composite` needed**, and Convex stays strictly typecheck-only (no JS emit).
- Build mode still writes a `.tsbuildinfo` for incrementality. Left to default it landed at `convex/tsconfig.tsbuildinfo`, polluting the repo. Redirected it to the gitignored `node_modules/.tmp/` (matching `app`/`node`):

  > `"tsBuildInfoFile": "../node_modules/.tmp/tsconfig.convex.tsbuildinfo"`

  (`../` because the path resolves relative to `convex/tsconfig.json`.)

**Proof it works:** temporarily added `const _x: number = "..."` to `convex/auth.config.ts` (a file *not* reachable from `src`, so a real before/after test):
- Before the fix: `pnpm lint` **passed** (error missed).
- After the fix: `pnpm lint` **failed** with `convex/auth.config.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.`
- Temp error then reverted.

## (B) gitignore agent scratch dirs

Added `.claude/worktrees/` and `.tmp.gitignored/` (conventions already in use) so untracked agent worktrees stop polluting `git status`. No directories deleted — just ignored.

## Verification (actual results)
- `pnpm lint` — passes
- `pnpm build` — passes (`vite build` OK)
- `pnpm test` — passes (5/5)
- Temp-error proof — confirmed as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrVv49ZydmFUGUVbVTGWeN
